### PR TITLE
Supprimé la virgule entre nom et prénom des auteurs, éditeurs, etc

### DIFF
--- a/universite-de-lausanne-histoire.csl
+++ b/universite-de-lausanne-histoire.csl
@@ -17,7 +17,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2019-01-14T07:45:58+01:00</updated>
+    <updated>2020-09-28T15:09:16+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -114,7 +114,7 @@
   </macro>
   <macro name="creator">
     <names variable="author">
-      <name sort-separator=", " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
+      <name sort-separator=" " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <et-al font-style="italic"/>
@@ -239,7 +239,7 @@
   </macro>
   <macro name="scientific-editor-name">
     <names variable="editor">
-      <name sort-separator=", " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
+      <name sort-separator=" " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <et-al font-style="italic"/>
@@ -249,7 +249,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name sort-separator=", " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
+      <name sort-separator=" " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <et-al font-style="italic"/>
@@ -267,7 +267,7 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <names variable="container-author">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="3" et-al-use-first="1">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <et-al font-style="italic"/>


### PR DESCRIPTION
Pour faire suite à la demande de ce jour de la part de nos collègues.
